### PR TITLE
Refactor frontend config to use theme settings

### DIFF
--- a/assets/wtf-config.js
+++ b/assets/wtf-config.js
@@ -1,524 +1,429 @@
 /**
  * WTF Configuration Manager
- * Central configuration for all integrations and system settings
- * Manages Shopify, Lightspeed POS, 2accept, and other service configurations
+ * Builds a secure, client-side configuration object sourced from theme settings
+ * and storefront-safe metafields. Secrets must be proxied through secure backend endpoints.
  */
-
-window.WTF_CONFIG = {
-  // Store Information
-  store: {
-    name: 'WTF - Welcome To Florida',
-    phone: '(239) 955-0314',
-    email: 'info@wtfswag.com',
-    address: {
-      street: '1520 SE 46th Ln, Unit B',
-      city: 'Cape Coral',
-      state: 'FL',
-      zip: '33904',
-      country: 'US'
-    },
-    hours: {
-      monday: '10:00 AM - 10:00 PM',
-      tuesday: '10:00 AM - 10:00 PM',
-      wednesday: '10:00 AM - 10:00 PM',
-      thursday: '10:00 AM - 10:00 PM',
-      friday: '10:00 AM - 11:00 PM',
-      saturday: '10:00 AM - 11:00 PM',
-      sunday: '12:00 PM - 9:00 PM'
-    },
-    timezone: 'America/New_York'
-  },
-
-  // Shopify Configuration
-  shopify: {
-    enabled: true,
-    domain: 'wtfswag.myshopify.com',
-    storefrontAccessToken: process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN,
-    adminAccessToken: process.env.SHOPIFY_ADMIN_ACCESS_TOKEN,
-    locationId: process.env.SHOPIFY_LOCATION_ID,
-    webhookSecret: process.env.SHOPIFY_WEBHOOK_SECRET,
-    
-    // Product mappings
-    products: {
-      customKratomTea: 'custom-kratom-tea',
-      customKavaDrink: 'custom-kava-drink',
-      thcDrinks: 'thc-drinks',
-      thcShots: 'thc-shots',
-      draftPours: 'draft-pours',
-      cannedDrinks: 'canned-drinks',
-      takeHomeItems: 'take-home-items'
-    },
-
-    // Collection mappings
-    collections: {
-      kratomTeas: 'kratom-teas',
-      kavaDrinks: 'kava-drinks',
-      thcProducts: 'thc-products',
-      beverages: 'beverages',
-      merchandise: 'merchandise'
-    }
-  },
-
-  // Lightspeed POS Integration
-  lightspeed: {
-    enabled: true,
-    apiUrl: 'https://api.lightspeedapp.com/API',
-    accountId: process.env.LIGHTSPEED_ACCOUNT_ID,
-    apiKey: process.env.LIGHTSPEED_API_KEY,
-    apiSecret: process.env.LIGHTSPEED_API_SECRET,
-    
-    // Sync settings
-    syncInterval: 30000, // 30 seconds
-    enableRealTimeSync: true,
-    enableInventorySync: true,
-    enableCustomerSync: true,
-    enableOrderSync: true,
-    
-    // Store settings
-    shopId: 1,
-    registerId: 1,
-    defaultEmployeeId: 1,
-    
-    // Product variant mapping (Shopify variant ID -> Lightspeed item ID)
-    variantMapping: {
-      // Kratom Teas
-      '12345678901': '1001', // Green Kratom Medium
-      '12345678902': '1002', // Green Kratom Large
-      '12345678903': '1003', // Red Kratom Medium
-      '12345678904': '1004', // Red Kratom Large
-      
-      // Kava Drinks
-      '12345678905': '1005', // Traditional Kava Medium
-      '12345678906': '1006', // Traditional Kava Large
-      '12345678907': '1007', // Flavored Kava Medium
-      '12345678908': '1008', // Flavored Kava Large
-      
-      // THC Products
-      '12345678909': '1009', // THC Drink Large
-      '12345678910': '1010', // THC Drink Gallon
-      '12345678911': '1011', // THC Shot 2.5mg
-      '12345678912': '1012', // THC Shot 5mg
-      '12345678913': '1013', // THC Shot 25mg
-      
-      // Draft Pours
-      '12345678914': '1014', // Draft Pour Small
-      '12345678915': '1015', // Draft Pour Large
-      
-      // Canned Drinks
-      '12345678916': '1016', // Energy Drink
-      '12345678917': '1017', // Relaxation Drink
-      
-      // Take Home Items
-      '12345678918': '1018', // Kratom Powder
-      '12345678919': '1019', // Kava Powder
-      '12345678920': '1020'  // Merchandise
-    }
-  },
-
-  // 2accept Payment Integration
-  twoaccept: {
-    enabled: true,
-    environment: 'production', // 'sandbox' or 'production'
-    publicKey: process.env.TWOACCEPT_PUBLIC_KEY,
-    secretKey: process.env.TWOACCEPT_SECRET_KEY,
-    merchantId: process.env.TWOACCEPT_MERCHANT_ID,
-    
-    // Payment method settings
-    enableSavedCards: true,
-    enableApplePay: true,
-    enableGooglePay: true,
-    enableCashPickup: true,
-    
-    // Supported payment methods
-    supportedMethods: [
-      'visa',
-      'mastercard',
-      'amex',
-      'discover',
-      'apple_pay',
-      'google_pay',
-      'cash_pickup'
-    ],
-    
-    // Currency settings
-    currency: 'USD',
-    country: 'US'
-  },
-
-  // Analytics and Tracking
-  analytics: {
-    googleAnalytics: {
-      enabled: true,
-      measurementId: process.env.GA4_MEASUREMENT_ID
-    },
-    facebookPixel: {
-      enabled: true,
-      pixelId: process.env.FACEBOOK_PIXEL_ID
-    },
-    tiktokPixel: {
-      enabled: true,
-      pixelId: process.env.TIKTOK_PIXEL_ID
-    }
-  },
-
-  // Email and SMS Notifications
-  notifications: {
-    email: {
-      enabled: true,
-      provider: 'sendgrid', // or 'mailgun', 'ses'
-      apiKey: process.env.SENDGRID_API_KEY,
-      fromEmail: 'orders@wtfswag.com',
-      fromName: 'WTF - Welcome To Florida'
-    },
-    sms: {
-      enabled: true,
-      provider: 'twilio',
-      accountSid: process.env.TWILIO_ACCOUNT_SID,
-      authToken: process.env.TWILIO_AUTH_TOKEN,
-      fromNumber: process.env.TWILIO_PHONE_NUMBER
-    }
-  },
-
-  // Blog and Content Management
-  blog: {
-    enabled: true,
-    postsPerPage: 6,
-    enableComments: false,
-    enableSocialSharing: true,
-    categories: [
-      'Kratom Education',
-      'Kava Culture',
-      'Cannabis News',
-      'Store Updates',
-      'Community Events',
-      'Health & Wellness'
-    ]
-  },
-
-  // Inventory Management
-  inventory: {
-    lowStockThreshold: 5,
-    outOfStockThreshold: 0,
-    enableLowStockAlerts: true,
-    enableBackorders: false,
-    reservationTimeout: 900000, // 15 minutes in milliseconds
-    
-    // Auto-reorder settings
-    enableAutoReorder: false,
-    reorderThreshold: 10,
-    reorderQuantity: 50
-  },
-
-  // Customer Management
-  customers: {
-    enableLoyaltyProgram: true,
-    pointsPerDollar: 1,
-    enableBirthdayRewards: true,
-    enableReferralProgram: true,
-    
-    // Age verification for THC products
-    enableAgeVerification: true,
-    minimumAge: 21,
-    requiredDocuments: ['drivers_license', 'passport', 'state_id']
-  },
-
-  // Ordering and Fulfillment
-  ordering: {
-    enableOnlineOrdering: true,
-    enablePickup: true,
-    enableDelivery: false, // Future feature
-    
-    // Pickup settings
-    pickupLocation: {
-      name: 'WTF Cape Coral',
-      address: '1520 SE 46th Ln, Unit B, Cape Coral, FL 33904',
+(function() {
+  const fallbackConfig = {
+    store: {
+      name: 'WTF - Welcome To Florida',
       phone: '(239) 955-0314',
-      instructions: 'Call when you arrive and we\'ll bring your order out!'
+      email: 'info@wtfswag.com',
+      address: {
+        line1: '1520 SE 46th Ln',
+        line2: 'Unit B',
+        city: 'Cape Coral',
+        region: 'FL',
+        postalCode: '33904',
+        country: 'US'
+      },
+      hours: {
+        monday: { open: '08:00', close: '22:00' },
+        tuesday: { open: '08:00', close: '22:00' },
+        wednesday: { open: '08:00', close: '22:00' },
+        thursday: { open: '08:00', close: '22:00' },
+        friday: { open: '08:00', close: '23:00' },
+        saturday: { open: '08:00', close: '23:00' },
+        sunday: { open: '10:00', close: '22:00' }
+      },
+      timezone: 'America/New_York'
     },
-    
-    // Order timing
-    preparationTime: {
-      kratom: 5, // minutes
-      kava: 7,
-      thc: 10,
-      draft: 3,
-      canned: 1
-    },
-    
-    // Operating hours for online orders
-    onlineOrderHours: {
-      monday: { open: '10:00', close: '22:00' },
-      tuesday: { open: '10:00', close: '22:00' },
-      wednesday: { open: '10:00', close: '22:00' },
-      thursday: { open: '10:00', close: '22:00' },
-      friday: { open: '10:00', close: '23:00' },
-      saturday: { open: '10:00', close: '23:00' },
-      sunday: { open: '12:00', close: '21:00' }
-    }
-  },
-
-  // Feature Flags
-  features: {
-    enableCustomDrinkBuilder: true,
-    enableFlavorRotation: true,
-    enableSeasonalMenus: true,
-    enableEventBooking: false, // Future feature
-    enableSubscriptions: false, // Future feature
-    enableGiftCards: false, // Future feature
-    enableRewards: true,
-    enableSocialLogin: false,
-    enableGuestCheckout: true,
-    enableMultiLocation: false // Future feature
-  },
-
-  // API Rate Limits
-  rateLimits: {
-    lightspeed: {
-      requestsPerSecond: 2,
-      burstLimit: 10
-    },
-    twoaccept: {
-      requestsPerSecond: 5,
-      burstLimit: 20
-    },
-    shopify: {
-      requestsPerSecond: 2,
-      burstLimit: 40
-    }
-  },
-
-  // Error Handling
-  errorHandling: {
-    enableErrorReporting: true,
-    enableUserFriendlyMessages: true,
-    fallbackToCache: true,
-    retryAttempts: 3,
-    retryDelay: 1000 // milliseconds
-  },
-
-  // Performance Settings
-  performance: {
-    enableCaching: true,
-    cacheTimeout: 300000, // 5 minutes
-    enableLazyLoading: true,
-    enableImageOptimization: true,
-    enableMinification: true
-  },
-
-  // Security Settings
-  security: {
-    enableCSP: true,
-    enableHSTS: true,
-    enableXSSProtection: true,
-    sessionTimeout: 3600000, // 1 hour
-    enableRateLimiting: true
-  },
-
-  // Development Settings
-  development: {
-    enableDebugMode: process.env.NODE_ENV === 'development',
-    enableConsoleLogging: process.env.NODE_ENV === 'development',
-    enablePerformanceMonitoring: true,
-    mockExternalAPIs: false
-  }
-};
-
-/**
- * Configuration Manager Class
- * Provides methods to safely access and update configuration
- */
-class WTFConfigManager {
-  constructor(config) {
-    this.config = config;
-    this.listeners = new Map();
-  }
-
-  /**
-   * Get configuration value by path
-   * @param {string} path - Dot notation path (e.g., 'shopify.products.customKratomTea')
-   * @param {*} defaultValue - Default value if path doesn't exist
-   */
-  get(path, defaultValue = null) {
-    const keys = path.split('.');
-    let current = this.config;
-
-    for (const key of keys) {
-      if (current && typeof current === 'object' && key in current) {
-        current = current[key];
-      } else {
-        return defaultValue;
-      }
-    }
-
-    return current;
-  }
-
-  /**
-   * Set configuration value by path
-   * @param {string} path - Dot notation path
-   * @param {*} value - Value to set
-   */
-  set(path, value) {
-    const keys = path.split('.');
-    const lastKey = keys.pop();
-    let current = this.config;
-
-    for (const key of keys) {
-      if (!(key in current) || typeof current[key] !== 'object') {
-        current[key] = {};
-      }
-      current = current[key];
-    }
-
-    const oldValue = current[lastKey];
-    current[lastKey] = value;
-
-    // Notify listeners
-    this.notifyListeners(path, value, oldValue);
-  }
-
-  /**
-   * Check if feature is enabled
-   * @param {string} featureName - Name of the feature
-   */
-  isFeatureEnabled(featureName) {
-    return this.get(`features.${featureName}`, false);
-  }
-
-  /**
-   * Get store information
-   */
-  getStoreInfo() {
-    return this.get('store');
-  }
-
-  /**
-   * Get integration configuration
-   * @param {string} integration - Integration name (shopify, lightspeed, twoaccept)
-   */
-  getIntegrationConfig(integration) {
-    return this.get(integration, {});
-  }
-
-  /**
-   * Check if integration is enabled
-   * @param {string} integration - Integration name
-   */
-  isIntegrationEnabled(integration) {
-    return this.get(`${integration}.enabled`, false);
-  }
-
-  /**
-   * Add configuration change listener
-   * @param {string} path - Path to watch
-   * @param {function} callback - Callback function
-   */
-  addListener(path, callback) {
-    if (!this.listeners.has(path)) {
-      this.listeners.set(path, []);
-    }
-    this.listeners.get(path).push(callback);
-  }
-
-  /**
-   * Remove configuration change listener
-   * @param {string} path - Path to stop watching
-   * @param {function} callback - Callback function to remove
-   */
-  removeListener(path, callback) {
-    const pathListeners = this.listeners.get(path);
-    if (pathListeners) {
-      const index = pathListeners.indexOf(callback);
-      if (index > -1) {
-        pathListeners.splice(index, 1);
-      }
-    }
-  }
-
-  /**
-   * Notify listeners of configuration changes
-   * @private
-   */
-  notifyListeners(path, newValue, oldValue) {
-    const pathListeners = this.listeners.get(path);
-    if (pathListeners) {
-      pathListeners.forEach(callback => {
-        try {
-          callback(newValue, oldValue, path);
-        } catch (error) {
-          console.error('Configuration listener error:', error);
+    integrations: {
+      shopify: {
+        enabled: true,
+        domain: null,
+        locationId: null,
+        endpoints: {
+          adminProxy: '/apps/wtf/shopify-admin'
+        },
+        products: {
+          customKratomTea: 'custom-kratom-tea',
+          customKavaDrink: 'custom-kava-drink',
+          thcDrinks: 'thc-drinks',
+          thcShots: 'thc-shots',
+          draftPours: 'draft-pours',
+          cannedDrinks: 'canned-drinks',
+          takeHomeItems: 'take-home-items'
+        },
+        collections: {
+          kratomTeas: 'kratom-teas',
+          kavaDrinks: 'kava-drinks',
+          thcProducts: 'thc-products',
+          beverages: 'beverages',
+          merchandise: 'merchandise'
         }
-      });
+      },
+      lightspeed: {
+        enabled: false,
+        accountId: null,
+        syncInterval: 30000,
+        variantMapping: {},
+        endpoints: {
+          base: '/apps/wtf/lightspeed',
+          inventory: '/apps/wtf/lightspeed/inventory',
+          availability: '/apps/wtf/lightspeed/availability',
+          reserve: '/apps/wtf/lightspeed/reserve',
+          release: '/apps/wtf/lightspeed/release',
+          sync: '/apps/wtf/lightspeed/sync',
+          orders: '/apps/wtf/lightspeed/orders'
+        }
+      },
+      twoaccept: {
+        enabled: false,
+        publicKey: null,
+        merchantId: null,
+        environment: 'production',
+        enableSavedCards: true,
+        enableApplePay: true,
+        enableGooglePay: true,
+        endpoints: {
+          base: '/apps/wtf/2accept',
+          paymentMethods: '/apps/wtf/2accept/payment-methods',
+          payments: '/apps/wtf/2accept/payments',
+          orders: '/apps/wtf/2accept/orders',
+          savedMethods: '/apps/wtf/2accept/customers',
+          merchantValidation: '/apps/wtf/2accept/apple-pay/validate',
+          applePay: '/apps/wtf/2accept/apple-pay'
+        }
+      }
+    },
+    analytics: {
+      google: {
+        measurementId: null,
+        enabled: false
+      },
+      googleAds: null,
+      metaPixel: null,
+      tiktokPixel: null,
+      snapchatPixel: null,
+      pinterestTag: null,
+      clarityProjectId: null,
+      hotjarSiteId: null
+    },
+    notifications: {
+      email: {
+        enabled: true,
+        provider: 'sendgrid',
+        apiKey: null,
+        fromEmail: 'orders@wtfswag.com',
+        fromName: 'WTF - Welcome To Florida'
+      },
+      sms: {
+        enabled: false,
+        provider: 'twilio',
+        accountSid: null,
+        authToken: null,
+        fromNumber: null
+      }
+    },
+    customers: {
+      enableLoyaltyProgram: true,
+      pointsPerDollar: 1,
+      enableBirthdayRewards: true,
+      enableReferralProgram: true,
+      enableAgeVerification: true,
+      minimumAge: 21,
+      requiredDocuments: ['drivers_license', 'passport', 'state_id']
+    },
+    ordering: {
+      enableOnlineOrdering: true,
+      enablePickup: true,
+      enableDelivery: false,
+      pickupLocation: {
+        name: 'WTF Cape Coral',
+        address: '1520 SE 46th Ln, Unit B, Cape Coral, FL 33904',
+        phone: '(239) 955-0314',
+        instructions: 'Call when you arrive and we\'ll bring your order out!'
+      },
+      preparationTime: {
+        kratom: 5,
+        kava: 7,
+        thc: 10,
+        draft: 3,
+        canned: 1
+      },
+      onlineOrderHours: {
+        monday: { open: '10:00', close: '22:00' },
+        tuesday: { open: '10:00', close: '22:00' },
+        wednesday: { open: '10:00', close: '22:00' },
+        thursday: { open: '10:00', close: '22:00' },
+        friday: { open: '10:00', close: '23:00' },
+        saturday: { open: '10:00', close: '23:00' },
+        sunday: { open: '12:00', close: '21:00' }
+      }
+    },
+    features: {
+      enableCustomDrinkBuilder: true,
+      enableFlavorRotation: true,
+      enableSeasonalMenus: true,
+      enableEventBooking: false,
+      enableSubscriptions: false,
+      enableGiftCards: false,
+      enableRewards: true,
+      enableSocialLogin: false,
+      enableGuestCheckout: true,
+      enableMultiLocation: false,
+      enableOfflineMode: false,
+      enableCustomCheckout: false
+    },
+    rateLimits: {
+      lightspeed: {
+        requestsPerSecond: 2,
+        burstLimit: 10
+      },
+      twoaccept: {
+        requestsPerSecond: 5,
+        burstLimit: 20
+      },
+      shopify: {
+        requestsPerSecond: 2,
+        burstLimit: 40
+      }
+    },
+    errorHandling: {
+      enableErrorReporting: true,
+      enableUserFriendlyMessages: true,
+      fallbackToCache: true,
+      retryAttempts: 3,
+      retryDelay: 1000
+    },
+    performance: {
+      enableCaching: true,
+      cacheTimeout: 300000,
+      enableLazyLoading: true,
+      enableImageOptimization: true,
+      enableMinification: true
+    },
+    security: {
+      enableCSP: true,
+      enableHSTS: true,
+      enableXSSProtection: true,
+      sessionTimeout: 3600000,
+      enableRateLimiting: true
+    },
+    development: {
+      enableDebugMode: false,
+      enableConsoleLogging: false,
+      enablePerformanceMonitoring: true,
+      mockExternalAPIs: false
+    },
+    endpoints: {
+      proxyBase: '/apps/wtf',
+      shopifyAdminProxy: '/apps/wtf/shopify-admin'
+    }
+  };
+
+  const clone = (value) => JSON.parse(JSON.stringify(value));
+  const isPlainObject = (value) => Object.prototype.toString.call(value) === '[object Object]';
+
+  function mergeDeep(target, source) {
+    if (!isPlainObject(target) || !isPlainObject(source)) {
+      return source;
+    }
+
+    Object.keys(source).forEach((key) => {
+      const sourceValue = source[key];
+      const targetValue = target[key];
+
+      if (Array.isArray(sourceValue)) {
+        target[key] = sourceValue.slice();
+      } else if (isPlainObject(sourceValue)) {
+        target[key] = mergeDeep(isPlainObject(targetValue) ? { ...targetValue } : {}, sourceValue);
+      } else if (sourceValue !== undefined) {
+        target[key] = sourceValue;
+      }
+    });
+
+    return target;
+  }
+
+  const initialConfig = (window.WTFConfig && typeof window.WTFConfig.get !== 'function'
+    ? window.WTFConfig
+    : null) || window.WTF_CONFIG_DATA || {};
+
+  const configData = mergeDeep(clone(fallbackConfig), initialConfig);
+
+  if (!configData.integrations) {
+    configData.integrations = {};
+  }
+
+  if (!configData.integrations.lightspeed && configData.lightspeed) {
+    configData.integrations.lightspeed = configData.lightspeed;
+  }
+
+  if (!configData.integrations.twoaccept && configData.twoaccept) {
+    configData.integrations.twoaccept = configData.twoaccept;
+  }
+
+  if (!configData.integrations.shopify && configData.shopify) {
+    configData.integrations.shopify = configData.shopify;
+  }
+
+  if (!configData.integrations.shopify) {
+    configData.integrations.shopify = fallbackConfig.integrations.shopify;
+  }
+
+  if (!configData.endpoints) {
+    configData.endpoints = fallbackConfig.endpoints;
+  }
+
+  if (!configData.integrations.shopify.domain && window.Shopify && window.Shopify.shop) {
+    configData.integrations.shopify.domain = window.Shopify.shop;
+  }
+
+  configData.shopify = configData.integrations.shopify;
+  configData.lightspeed = configData.integrations.lightspeed;
+  configData.twoaccept = configData.integrations.twoaccept;
+
+  class WTFConfigManager {
+    constructor(config) {
+      this.config = config;
+      this.listeners = new Map();
+    }
+
+    get(path, defaultValue = null) {
+      if (!path) return defaultValue;
+
+      const keys = path.split('.');
+      let current = this.config;
+
+      for (const key of keys) {
+        if (current && typeof current === 'object' && key in current) {
+          current = current[key];
+        } else {
+          return defaultValue;
+        }
+      }
+
+      return current;
+    }
+
+    set(path, value) {
+      if (!path) return;
+
+      const keys = path.split('.');
+      const lastKey = keys.pop();
+      let current = this.config;
+
+      for (const key of keys) {
+        if (!(key in current) || typeof current[key] !== 'object') {
+          current[key] = {};
+        }
+        current = current[key];
+      }
+
+      const oldValue = current[lastKey];
+      current[lastKey] = value;
+
+      this.notifyListeners(path, value, oldValue);
+    }
+
+    isFeatureEnabled(featureName) {
+      return this.get(`features.${featureName}`, false);
+    }
+
+    getStoreInfo() {
+      return this.get('store');
+    }
+
+    getIntegrationConfig(integration) {
+      return this.get(`integrations.${integration}`, this.get(integration, {}));
+    }
+
+    isIntegrationEnabled(integration) {
+      return this.get(`integrations.${integration}.enabled`, this.get(`${integration}.enabled`, false));
+    }
+
+    addListener(path, callback) {
+      if (!this.listeners.has(path)) {
+        this.listeners.set(path, []);
+      }
+      this.listeners.get(path).push(callback);
+    }
+
+    removeListener(path, callback) {
+      const pathListeners = this.listeners.get(path);
+      if (pathListeners) {
+        const index = pathListeners.indexOf(callback);
+        if (index > -1) {
+          pathListeners.splice(index, 1);
+        }
+      }
+    }
+
+    notifyListeners(path, newValue, oldValue) {
+      const pathListeners = this.listeners.get(path);
+      if (pathListeners) {
+        pathListeners.forEach((callback) => {
+          try {
+            callback(newValue, oldValue, path);
+          } catch (error) {
+            console.error('WTF Configuration listener error:', error);
+          }
+        });
+      }
+    }
+
+    validate() {
+      const errors = [];
+
+      if (this.isIntegrationEnabled('shopify')) {
+        if (!this.get('integrations.shopify.domain')) {
+          errors.push('Shopify domain is required');
+        }
+      }
+
+      if (this.isIntegrationEnabled('lightspeed')) {
+        if (!this.get('integrations.lightspeed.accountId')) {
+          errors.push('Lightspeed account ID is required');
+        }
+      }
+
+      if (this.isIntegrationEnabled('twoaccept')) {
+        if (!this.get('integrations.twoaccept.publicKey')) {
+          errors.push('2accept public key is required');
+        }
+        if (!this.get('integrations.twoaccept.merchantId')) {
+          errors.push('2accept merchant ID is required');
+        }
+      }
+
+      return {
+        isValid: errors.length === 0,
+        errors
+      };
+    }
+
+    getEnvironmentConfig() {
+      const isDevelopment = this.get('development.enableDebugMode', false);
+      const twoAcceptEnvironment = this.get('integrations.twoaccept.environment', 'production');
+
+      return {
+        isDevelopment,
+        isProduction: !isDevelopment,
+        integrations: {
+          twoaccept: {
+            environment: twoAcceptEnvironment
+          },
+          lightspeed: {
+            proxyBase: this.get('integrations.lightspeed.endpoints.base')
+          }
+        }
+      };
     }
   }
 
-  /**
-   * Validate configuration
-   */
-  validate() {
-    const errors = [];
+  const manager = new WTFConfigManager(configData);
+  manager.raw = configData;
+  manager.merge = function(partialConfig) {
+    if (!isPlainObject(partialConfig)) return;
+    mergeDeep(this.raw, partialConfig);
+  };
 
-    // Check required Shopify settings
-    if (this.isIntegrationEnabled('shopify')) {
-      if (!this.get('shopify.domain')) {
-        errors.push('Shopify domain is required');
-      }
-      if (!this.get('shopify.storefrontAccessToken')) {
-        errors.push('Shopify storefront access token is required');
-      }
-    }
+  window.WTFConfig = manager;
+  window.WTF_CONFIG_DATA = configData;
 
-    // Check required Lightspeed settings
-    if (this.isIntegrationEnabled('lightspeed')) {
-      if (!this.get('lightspeed.accountId')) {
-        errors.push('Lightspeed account ID is required');
-      }
-      if (!this.get('lightspeed.apiKey')) {
-        errors.push('Lightspeed API key is required');
-      }
-    }
-
-    // Check required 2accept settings
-    if (this.isIntegrationEnabled('twoaccept')) {
-      if (!this.get('twoaccept.publicKey')) {
-        errors.push('2accept public key is required');
-      }
-      if (!this.get('twoaccept.merchantId')) {
-        errors.push('2accept merchant ID is required');
-      }
-    }
-
-    return {
-      isValid: errors.length === 0,
-      errors
-    };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { WTFConfigManager, WTFConfig: manager };
   }
-
-  /**
-   * Get environment-specific configuration
-   */
-  getEnvironmentConfig() {
-    const isDevelopment = this.get('development.enableDebugMode', false);
-    
-    return {
-      isDevelopment,
-      isProduction: !isDevelopment,
-      apiUrls: {
-        lightspeed: isDevelopment 
-          ? 'https://api.lightspeedapp.com/API' 
-          : 'https://api.lightspeedapp.com/API',
-        twoaccept: isDevelopment
-          ? 'https://sandbox-api.2accept.com/v1'
-          : 'https://api.2accept.com/v1'
-      }
-    };
-  }
-}
-
-// Create global configuration manager instance
-window.WTFConfig = new WTFConfigManager(window.WTF_CONFIG);
-
-// Export for use in other modules
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = { WTF_CONFIG: window.WTF_CONFIG, WTFConfigManager };
-}
+})();

--- a/config/settings_schema.json
+++ b/config/settings_schema.json
@@ -530,19 +530,31 @@
     "settings": [
       {
         "type": "header",
-        "content": "Lightspeed POS Integration"
+        "content": "Secure Integration Proxy"
+      },
+      {
+        "type": "text",
+        "id": "integration_proxy_base_path",
+        "label": "Proxy base path",
+        "default": "/apps/wtf",
+        "info": "Root path for the secure backend proxy that handles Lightspeed, 2accept, and Shopify Admin requests."
+      },
+      {
+        "type": "text",
+        "id": "shopify_admin_proxy_path",
+        "label": "Shopify Admin proxy path",
+        "default": "/apps/wtf/shopify-admin",
+        "info": "Relative path to the secure endpoint that performs Shopify Admin operations."
+      },
+      {
+        "type": "header",
+        "content": "Lightspeed POS (public storefront config)"
       },
       {
         "type": "text",
         "id": "lightspeed_account_id",
         "label": "Lightspeed Account ID",
         "info": "Your Lightspeed Retail account ID for inventory sync"
-      },
-      {
-        "type": "password",
-        "id": "lightspeed_api_key",
-        "label": "Lightspeed API Key",
-        "info": "API key for Lightspeed integration (keep secure)"
       },
       {
         "type": "checkbox",
@@ -563,7 +575,7 @@
       },
       {
         "type": "header",
-        "content": "2accept Payment Gateway"
+        "content": "2accept Payment Gateway (public storefront config)"
       },
       {
         "type": "text",

--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -100,57 +100,135 @@
 
     {%- comment %} Load WTF Configuration {%- endcomment %}
     <script>
-      // Environment variables and configuration
-      window.WTF_ENV = {
-        shopDomain: '{{ shop.permanent_domain }}',
-        cartToken: '{{ cart.token }}',
-        customerId: {% if customer %}{{ customer.id }}{% else %}null{% endif %},
-        customerEmail: {% if customer %}'{{ customer.email }}'{% else %}null{% endif %},
-        currency: '{{ cart.currency.iso_code }}',
-        locale: '{{ request.locale.iso_code }}',
-        routes: {
-          cart_add_url: '{{ routes.cart_add_url }}',
-          cart_change_url: '{{ routes.cart_change_url }}',
-          cart_update_url: '{{ routes.cart_update_url }}',
-          cart_url: '{{ routes.cart_url }}',
-          predictive_search_url: '{{ routes.predictive_search_url }}',
-          root_url: '{{ routes.root_url }}'
-        }
-      };
+      (function() {
+        const storeHours = {% if shop.metafields.wtf.hours.value %}{{ shop.metafields.wtf.hours.value }}{% else %}null{% endif %};
+        const storeAddress = {% if shop.metafields.wtf.address.value %}{{ shop.metafields.wtf.address.value }}{% else %}null{% endif %};
+        const integrationEndpoints = {% if shop.metafields.wtf.integration_endpoints.value %}{{ shop.metafields.wtf.integration_endpoints.value }}{% else %}null{% endif %};
+        const lightspeedVariantMap = {% if shop.metafields.wtf.lightspeed_variant_map.value %}{{ shop.metafields.wtf.lightspeed_variant_map.value }}{% else %}{}{% endif %};
+        const metafieldPhone = {% if shop.metafields.wtf.phone %}{{ shop.metafields.wtf.phone | json }}{% else %}null{% endif %};
+        const metafieldEmail = {% if shop.metafields.wtf.email %}{{ shop.metafields.wtf.email | json }}{% else %}null{% endif %};
+        const metafieldTimezone = {% if shop.metafields.wtf.timezone %}{{ shop.metafields.wtf.timezone | json }}{% else %}null{% endif %};
+        const proxyBaseSetting = {{ settings.integration_proxy_base_path | default: '/apps/wtf' | json }};
+        const adminProxyPath = {{ settings.shopify_admin_proxy_path | default: '/apps/wtf/shopify-admin' | json }};
+        const normalizedProxyBase = (proxyBaseSetting || '/apps/wtf').replace(/\/$/, '');
+        const lightspeedBase = integrationEndpoints?.lightspeed?.base || `${normalizedProxyBase}/lightspeed`;
+        const twoAcceptBase = integrationEndpoints?.twoaccept?.base || `${normalizedProxyBase}/2accept`;
 
-      // Integration settings (these would come from your admin settings)
-      window.WTF_INTEGRATION_CONFIG = {
-        lightspeed: {
-          enabled: true,
-          accountId: '{{ settings.lightspeed_account_id }}',
-          // API key would be handled server-side for security
-          syncInterval: 30000,
-          enableRealTimeSync: true
-        },
-        twoaccept: {
-          enabled: true,
-          publicKey: '{{ settings.twoaccept_public_key }}',
-          merchantId: '{{ settings.twoaccept_merchant_id }}',
-          environment: '{{ settings.twoaccept_environment | default: "production" }}',
-          enableSavedCards: true,
-          enableApplePay: true,
-          enableGooglePay: true
-        },
-        analytics: {
-          googleAnalytics: {
-            enabled: {% if settings.google_analytics_id != blank %}true{% else %}false{% endif %},
-            measurementId: '{{ settings.google_analytics_id }}'
-          },
-          facebookPixel: {
-            enabled: {% if settings.facebook_pixel_id != blank %}true{% else %}false{% endif %},
-            pixelId: '{{ settings.facebook_pixel_id }}'
-          },
-          tiktokPixel: {
-            enabled: {% if settings.tiktok_pixel_id != blank %}true{% else %}false{% endif %},
-            pixelId: '{{ settings.tiktok_pixel_id }}'
+        window.WTF_ENV = {
+          shopDomain: {{ shop.permanent_domain | json }},
+          cartToken: {{ cart.token | json }},
+          customerId: {% if customer %}{{ customer.id | json }}{% else %}null{% endif %},
+          customerEmail: {% if customer %}{{ customer.email | json }}{% else %}null{% endif %},
+          currency: {{ cart.currency.iso_code | default: shop.currency | json }},
+          locale: {{ request.locale.iso_code | json }},
+          routes: {
+            cart_add_url: {{ routes.cart_add_url | json }},
+            cart_change_url: {{ routes.cart_change_url | json }},
+            cart_update_url: {{ routes.cart_update_url | json }},
+            cart_url: {{ routes.cart_url | json }},
+            predictive_search_url: {{ routes.predictive_search_url | json }},
+            root_url: {{ routes.root_url | json }}
           }
-        }
-      };
+        };
+
+        const resolvedAddress = storeAddress || {
+          line1: {{ settings.store_address_1 | json }},
+          line2: {{ settings.store_address_2 | json }},
+          city: {{ settings.store_city | json }},
+          region: {{ settings.store_state | json }},
+          postalCode: {{ settings.store_zip | json }},
+          country: 'US'
+        };
+
+        const resolvedHours = storeHours || {
+          monday: { open: '08:00', close: '22:00' },
+          tuesday: { open: '08:00', close: '22:00' },
+          wednesday: { open: '08:00', close: '22:00' },
+          thursday: { open: '08:00', close: '22:00' },
+          friday: { open: '08:00', close: '23:00' },
+          saturday: { open: '08:00', close: '23:00' },
+          sunday: { open: '10:00', close: '22:00' }
+        };
+
+        const fallbackPhone = {{ settings.store_phone | default: shop.phone | json }};
+        const fallbackEmail = {{ settings.store_email | default: shop.customer_email | default: shop.email | json }};
+        const lightspeedEnabled = {{ settings.lightspeed_enable_sync | json }};
+        const lightspeedSyncInterval = {{ settings.lightspeed_sync_interval | default: 30 | times: 1000 }};
+        const twoAcceptEnabled = {{ settings.twoaccept_public_key != blank | json }};
+
+        window.WTFConfig = {
+          store: {
+            name: {{ shop.name | json }},
+            phone: metafieldPhone || fallbackPhone,
+            email: metafieldEmail || fallbackEmail,
+            address: resolvedAddress,
+            hours: resolvedHours,
+            timezone: metafieldTimezone || 'America/New_York'
+          },
+          integrations: {
+            shopify: {
+              enabled: true,
+              domain: {{ shop.permanent_domain | json }},
+              locationId: null,
+              endpoints: {
+                adminProxy: adminProxyPath
+              }
+            },
+            lightspeed: {
+              enabled: lightspeedEnabled,
+              accountId: {{ settings.lightspeed_account_id | json }},
+              syncInterval: lightspeedSyncInterval,
+              variantMapping: lightspeedVariantMap,
+              endpoints: {
+                base: lightspeedBase,
+                inventory: integrationEndpoints?.lightspeed?.inventory || `${lightspeedBase}/inventory`,
+                availability: integrationEndpoints?.lightspeed?.availability || `${lightspeedBase}/availability`,
+                reserve: integrationEndpoints?.lightspeed?.reserve || `${lightspeedBase}/reserve`,
+                release: integrationEndpoints?.lightspeed?.release || `${lightspeedBase}/release`,
+                sync: integrationEndpoints?.lightspeed?.sync || `${lightspeedBase}/sync`,
+                orders: integrationEndpoints?.lightspeed?.orders || `${lightspeedBase}/orders`
+              }
+            },
+            twoaccept: {
+              enabled: twoAcceptEnabled,
+              publicKey: {{ settings.twoaccept_public_key | json }},
+              merchantId: {{ settings.twoaccept_merchant_id | json }},
+              environment: {{ settings.twoaccept_environment | default: 'production' | json }},
+              enableSavedCards: {{ settings.twoaccept_enable_saved_cards | json }},
+              enableApplePay: {{ settings.twoaccept_enable_apple_pay | json }},
+              enableGooglePay: {{ settings.twoaccept_enable_google_pay | json }},
+              endpoints: {
+                base: twoAcceptBase,
+                paymentMethods: integrationEndpoints?.twoaccept?.paymentMethods || `${twoAcceptBase}/payment-methods`,
+                payments: integrationEndpoints?.twoaccept?.payments || `${twoAcceptBase}/payments`,
+                orders: integrationEndpoints?.twoaccept?.orders || `${twoAcceptBase}/orders`,
+                savedMethods: integrationEndpoints?.twoaccept?.savedMethods || `${twoAcceptBase}/customers`,
+                merchantValidation: integrationEndpoints?.twoaccept?.merchantValidation || `${twoAcceptBase}/apple-pay/validate`,
+                applePay: integrationEndpoints?.twoaccept?.applePay || `${twoAcceptBase}/apple-pay`
+              }
+            }
+          },
+          analytics: {
+            google: {
+              measurementId: {{ settings.google_analytics_id | json }},
+              enabled: {{ settings.google_analytics_id != blank | json }}
+            },
+            googleAds: {{ settings.google_ads_id | json }},
+            metaPixel: {{ settings.facebook_pixel_id | json }},
+            tiktokPixel: {{ settings.tiktok_pixel_id | json }},
+            snapchatPixel: {{ settings.snapchat_pixel_id | json }},
+            pinterestTag: {{ settings.pinterest_tag_id | json }},
+            clarityProjectId: {{ settings.clarity_project_id | json }},
+            hotjarSiteId: {{ settings.hotjar_site_id | json }}
+          },
+          endpoints: {
+            proxyBase: normalizedProxyBase,
+            shopifyAdminProxy: adminProxyPath
+          }
+        };
+
+        window.WTF_CONFIG_DATA = window.WTFConfig;
+      })();
     </script>
 
     {%- comment %} Load WTF Configuration Manager {%- endcomment %}
@@ -453,7 +531,7 @@
       <script>
         // Development debugging tools
         window.WTF_DEBUG = {
-          config: () => console.table(window.WTF_CONFIG),
+          config: () => console.table(window.WTFConfig?.raw || window.WTF_CONFIG_DATA || {}),
           integrations: () => console.log('Integrations:', {
             lightspeed: !!window.WTFLightspeed,
             twoaccept: !!window.WTF2Accept,


### PR DESCRIPTION
## Summary
- expose secure proxy and public key fields in the theme schema for Lightspeed, 2accept, and Shopify admin
- hydrate `window.WTF_ENV` and `window.WTFConfig` from theme settings + metafields so storefront JS only receives public data
- update the global config manager and Lightspeed/2accept integrations to consume the new config shape and call backend proxies instead of direct APIs

## Testing
- `npm run theme:check` *(fails: Shopify CLI is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68dc0daf4d9883329a413d8ce8f94f6a